### PR TITLE
fix: use PodsPruned metric when pruning pods

### DIFF
--- a/pruner/internal/resources/containers.go
+++ b/pruner/internal/resources/containers.go
@@ -146,7 +146,7 @@ func DeleteContainers(clientset *kubernetes.Clientset, containers []ContainerInf
 				fmt.Sprintf("pod:%s", container.PodName),
 				fmt.Sprintf("namespace:%s", container.Namespace),
 			}
-			metrics.ContainersPruned.WithLabelValues(container.Namespace, container.Status).Add(1) // Increment the counter
+			metrics.PodsPruned.WithLabelValues(container.Namespace, container.Status).Add(1) // Increment the counter
 			utils.LogWithFields(logrus.InfoLevel, message, "Successfully deleted pod")
 		}
 	}


### PR DESCRIPTION
## Summary
Fixes incorrect metric usage in `DeleteContainers` function. Previously, the code was incrementing `ContainersPruned` metric when deleting pods, causing `pods_pruned_total` to always show zero while `containers_pruned_total` incorrectly counted pod deletions.

## Changes
- Changed `metrics.ContainersPruned` to `metrics.PodsPruned` in `DeleteContainers` function (line 149)

## Verification
- [x] Application builds successfully
- [x] Tests pass with race detector
- [x] `PodsPruned` metric is now properly used in the codebase

## Related
Fixes metric naming inconsistency where `PodsPruned` was defined but never used.