### PR TITLE
fix: add pagination for job listing and use correct metrics counter

### DIFF
--- a/pruner/internal/resources/containers.go
+++ b/pruner/internal/resources/containers.go
@@ -146,7 +146,7 @@ func DeleteContainers(clientset *kubernetes.Clientset, containers []ContainerInf
 				fmt.Sprintf("pod:%s", container.PodName),
 				fmt.Sprintf("namespace:%s", container.Namespace),
 			}
-			metrics.PodsPruned.WithLabelValues(container.Namespace, container.Status).Add(1) // Increment the counter
+			metrics.ContainersPruned.WithLabelValues(container.Namespace, container.Status).Add(1) // Increment the counter
 			utils.LogWithFields(logrus.InfoLevel, message, "Successfully deleted pod")
 		}
 	}

--- a/pruner/internal/resources/jobs.go
+++ b/pruner/internal/resources/jobs.go
@@ -45,25 +45,36 @@ func GetJobs(clientset *kubernetes.Clientset, namespace string, log *logrus.Logg
 	statuses := strings.Split(strings.TrimSpace(utils.GetEnv("JOB_STATUSES", "Complete", log)), ",")
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	jobs, err := clientset.BatchV1().Jobs(namespace).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		utils.LogWithFields(logrus.ErrorLevel, []string{}, "Error retrieving jobs", err)
-		return nil, err
-	}
 
-	var jobsList []ContainerInfo
-	for _, job := range jobs.Items {
-		for _, jobStatus := range job.Status.Conditions {
-			if utils.Contains(statuses, string(jobStatus.Type)) {
-				jobsList = append(jobsList, ContainerInfo{
-					Namespace: job.Namespace,
-					PodName:   job.Name,
-					Status:    string(jobStatus.Type),
-				})
+	var allJobs []ContainerInfo
+	listOptions := metav1.ListOptions{Limit: 100}
+
+	for {
+		jobList, err := clientset.BatchV1().Jobs(namespace).List(ctx, listOptions)
+		if err != nil {
+			utils.LogWithFields(logrus.ErrorLevel, []string{}, "Error retrieving jobs", err)
+			return nil, err
+		}
+
+		for _, job := range jobList.Items {
+			for _, jobStatus := range job.Status.Conditions {
+				if utils.Contains(statuses, string(jobStatus.Type)) {
+					allJobs = append(allJobs, ContainerInfo{
+						Namespace: job.Namespace,
+						PodName:   job.Name,
+						Status:    string(jobStatus.Type),
+					})
+				}
 			}
 		}
+
+		if jobList.Continue == "" {
+			break
+		}
+		listOptions.Continue = jobList.Continue
 	}
-	return jobsList, nil
+
+	return allJobs, nil
 }
 
 // DeleteJobs deletes the specified jobs from the given namespace and logs the actions taken.


### PR DESCRIPTION
## Summary
This PR addresses two issues:

### 1. Pagination Support for Job Listings
Added pagination support to `GetJobs()` function to handle namespaces with many jobs efficiently. Previously, all jobs were fetched in a single call which could hit API server limits.

**Changes in `pruner/internal/resources/jobs.go`:**
- Implemented pagination loop with `Limit: 100` (matching `GetContainers()` implementation)
- Uses `Continue` token for paginated fetching
- Properly handles context timeout throughout the operation

### 2. Fix Metrics Counter
Changed from `PodsPruned` to `ContainersPruned` in `DeleteContainers()` function to correctly increment the containers-specific metric counter when pruning containers.

**Changes in `pruner/internal/resources/containers.go`:**
- Fixed: `metrics.PodsPruned` → `metrics.ContainersPruned`

## Verification
- [x] Code compiles successfully
- [x] Pagination logic mirrors existing `GetContainers()` implementation
- [x] Correct metrics counter is now used for container pruning

## Related
- Fixes pagination issue similar to `GetContainers()` implementation
- Corrects metrics labeling for accurate monitoring